### PR TITLE
feat: add global and front-page messages

### DIFF
--- a/othello/settings/__init__.py
+++ b/othello/settings/__init__.py
@@ -201,6 +201,12 @@ JAILEDRUNNER_DRIVER = os.path.abspath(os.path.join(os.path.dirname(BASE_DIR), "r
 CLIENT_HEARTBEAT_INTERVAL = 5  # seconds
 IMPORT_TIMEOUT = 1  # seconds
 
+# Message to display on the front page. HTML not escaped, be careful.
+FRONT_PAGE_MESSAGE = ""
+
+# Message to display on every page. HTML not escaped, be careful.
+GLOBAL_MESSAGE = ""
+
 # Game settings
 STALE_GAME = 6  # hours
 YOURSELF_TIMEOUT = 300  # seconds

--- a/othello/settings/secret.sample.py
+++ b/othello/settings/secret.sample.py
@@ -30,3 +30,9 @@ CELERY_BROKER_URL = "redis://localhost/1"
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 SOCIAL_AUTH_ION_KEY = ""
 SOCIAL_AUTH_ION_SECRET = ""
+
+# Message to display on the front page. HTML not escaped, be careful.
+FRONT_PAGE_MESSAGE = ""
+
+# Message to display on every page. HTML not escaped, be careful.
+GLOBAL_MESSAGE = ""

--- a/othello/templates/auth/index.html
+++ b/othello/templates/auth/index.html
@@ -12,6 +12,16 @@
                 <span aria-hidden="true">&times;</span>
             </button>
         </div>
+
+        {# Front page message #}
+        {% if settings.FRONT_PAGE_MESSAGE %}
+            <div class="alert alert-warning alert-dismissible fade show my-2" role="alert">
+                {{ settings.FRONT_PAGE_MESSAGE|safe }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        {% endif %}
     </div>
     <p>
         Welcome to the TJ AI Othello tournament home page! Click on any of the links above to navigate.

--- a/othello/templates/base.html
+++ b/othello/templates/base.html
@@ -75,6 +75,15 @@
                         </button>
                     </div>
                 {% endfor %}
+                {# Global message #}
+                {% if settings.GLOBAL_MESSAGE %}
+                    <div class="alert alert-warning alert-dismissible fade show my-2" role="alert">
+                        {{ settings.GLOBAL_MESSAGE|safe }}
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                {% endif %}
             </div>
         {% block main %}{% endblock %}
         <br>


### PR DESCRIPTION
Adds the ability to add global and front-page only messages.

For instance, these are screenshots with the global message "This is a test 2" and the front-page only message "Hello! This is a test":

![image](https://user-images.githubusercontent.com/3579871/106373376-d8238880-6346-11eb-9e0d-e0c3c4e4e59b.png)

![image](https://user-images.githubusercontent.com/3579871/106373386-df4a9680-6346-11eb-90ae-543fe730e561.png)
