### PR TITLE
Update jailed_runners.py

### DIFF
--- a/othello/moderator/jailed_runners.py
+++ b/othello/moderator/jailed_runners.py
@@ -48,7 +48,7 @@ class LocalRunner:  # Called from JailedRunner, inherits accessibility restricti
             p.start()
             s = perf_counter()
             p.join(time_limit)
-            extra_time = int(time_limit - (perf_counter() - s))
+            extra_time = round(time_limit - (perf_counter() - s))
             if p.is_alive():
                 is_running.value = 0
                 p.join(0.05)


### PR DESCRIPTION
Instead of truncating extra time when time hoarding is enabled, round to the nearest integer.

Current: 0.9s extra time = 0s extra time

Proposed: 0.9s extra time = 1s extra time

Dr. G might want this.