### PR TITLE
tournaments: replace game name with user name

### DIFF
--- a/othello/apps/tournaments/forms.py
+++ b/othello/apps/tournaments/forms.py
@@ -24,8 +24,8 @@ class TournamentCreateForm(forms.ModelForm):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(TournamentCreateForm, self).__init__(*args, **kwargs)
-        self.fields["include_users"].label_from_instance = Submission.get_game_name
-        self.fields["bye_player"].label_from_instance = Submission.get_game_name
+        self.fields["include_users"].label_from_instance = Submission.get_user_name
+        self.fields["bye_player"].label_from_instance = Submission.get_user_name
 
     def clean(self) -> None:
         cd = self.cleaned_data

--- a/othello/static/js/tournaments/create.js
+++ b/othello/static/js/tournaments/create.js
@@ -9,9 +9,7 @@ function readUsers(text){
         else
             add_error(`Cannot find entry for user ${file_users[i].trim()}`)
     }
-
 }
-
 
 window.onload = function () {
     $("option").each(function () {

--- a/othello/templates/tournaments/create.html
+++ b/othello/templates/tournaments/create.html
@@ -8,6 +8,11 @@
         .selectize-control {
             width: 10vw;
         }
+        #user_group .selectize-input{
+            overflow-y: scroll;
+            height: 25vh !important;
+            width: 20vw;
+        }
     </style>
 {% endblock %}
 {% block main %}
@@ -39,7 +44,7 @@
                 </p>
                 <br>
                 <br>
-                <p class="row" style="margin-left: 0; margin-bottom: 0">
+                <p id="user_group" class="row" style="margin-left: 0; margin-bottom: 0">
                     {{ form.include_users.label }}
                     {{ form.include_users }}
                 </p>
@@ -55,7 +60,7 @@
             </form>
         </div>
         <div class="align-content-center col-lg-5" id="right-side">
-            <div style="height: 50%">
+            <div style="height: 40%">
                 <h4>In Progress Tournaments</h4>
                 <ul>
                     {% for tournament in in_progress %}
@@ -65,7 +70,7 @@
                     {% endfor %}
                 </ul>
             </div>
-            <div style="height: 50%">
+            <div style="height: 40%">
                 <h4>Scheduled Tournaments</h4>
                 <ul>
                     {% for tournament in future %}


### PR DESCRIPTION
- User username instead of game name to add players to tournaments (standardizes with student ID in CSVs)
- Fix formatting of include_users box (used to expand infinitely and was too skinny)